### PR TITLE
Add last commit from c4irp, adapt building to macOS

### DIFF
--- a/include/libchirp/chirp.h
+++ b/include/libchirp/chirp.h
@@ -14,26 +14,24 @@
 
 // .. c:type:: ch_config_t
 //
-//   TODO fix types
-//
 //    Chirp configuration.
 //
-//    .. c:member:: int REUSE_TIME
+//    .. c:member:: float REUSE_TIME
 //
-//       Time till a connection gets garbage collected during this time the
+//       Time until a connection gets garbage collected. After this the
 //       connection will be reused.
 //
-//    .. c:member:: int TIMEOUT
+//    .. c:member:: float TIMEOUT
 //
 //       General IO related timeout.
 //
-//    .. c:member:: int PORT
+//    .. c:member:: uint16_t PORT
 //
-//       Listen-port.
+//       Port for listening to connections.
 //
-//    .. c:member:: int BACKLOG
+//    .. c:member:: uint8_t BACKLOG
 //
-//       TCP-Listen socket backlog.
+//       TCP-listen socket backlog.
 //
 //    .. c:member:: uint8_t RETRIES
 //
@@ -41,13 +39,8 @@
 //
 //    .. c:member:: uint8_t MAX_HANDLERS
 //
-//       Count of handlers used. Allowed values between 1 and 32. Default: 16.
-//       If FLOW_CONTROL is on it must be >= 16.
-//
-//    .. c:member:: char FLOW_CONTROL
-//
-//       Flow control prevents overload of one node in chain for workers.
-//       Default: 1.
+//       Count of handlers used. Allowed values are values between 1 and 32.
+//       The default value is 16. If FLOW_CONTROL is on, it must be >= 16.
 //
 //    .. c:member:: char ACKNOWLEDGE
 //
@@ -56,31 +49,43 @@
 //       the risk of overloading the remote and the local machine. You have to
 //       set RETRIES and FLOW_CONTROL to 0 or chirp won't accept the config.
 //
+//    .. c:member:: char FLOW_CONTROL
+//
+//       Flow control prevents overloading of a node in a chain for workers.
+//       Default: 1.
+//
 //    .. c:member:: char CLOSE_ON_SIGINT
 //
-//       By default chirp closes on SIGINT (Ctrl-C)
+//       By default chirp closes on SIGINT (Ctrl-C).
 //
 //    .. c:member:: uint32_t BUFFER_SIZE
 //
 //       Size of the buffer used for a connection. Defaults to 0, which means
 //       use the size requested by libuv. Should not be set below 1024.
 //
-//    .. c:member:: char[16] BIND_V6
+//    .. c:member:: uint8_t[16] BIND_V6
 //
 //       Override IPv6 bind address.
 //
-//    .. c:member:: char[4] BIND_V4
+//    .. c:member:: uint8_t[4] BIND_V4
 //
 //       Override IPv4 bind address.
 //
-//    .. c:member:: unsigned char[16] IDENTITY
+//    .. c:member:: uint8_t[16] IDENTITY
 //
 //       Override the IDENTITY. By default all chars are 0, which means chirp
 //       will generate a IDENTITY.
 //
+//    .. c:member:: char* CERT_CHAIN_PEM
+//
+//       Holds the verification certificate.
+//
+//    .. c:member:: char* DH_PARAMS_PEM
+//
+//       Holds the path to the file containing DH parameters.
 //
 // .. code-block:: cpp
-
+//
 typedef struct ch_config_s {
     float           REUSE_TIME;
     float           TIMEOUT;
@@ -99,7 +104,6 @@ typedef struct ch_config_s {
     char*           DH_PARAMS_PEM;
 } ch_config_t;
 
-
 // .. c:type:: ch_chirp_int_t
 //    :noindex:
 //
@@ -117,7 +121,7 @@ typedef struct ch_chirp_int_s ch_chirp_int_t;
 //    internal data structures.
 //
 // .. code-block:: cpp
-
+//
 typedef struct ch_chirp_s {
     ch_chirp_int_t*    _;
     ch_log_cb_t        _log;
@@ -184,7 +188,8 @@ ch_chirp_get_loop(ch_chirp_t* chirp);
 //
 //    :param ch_chirp_t chirp: Chirp object
 //
-//    TODO: Document return value
+//    :return: a libuv event loop object.
+//    :rtype:  uv_loop_t*
 //
 
 // .. c:function::
@@ -205,7 +210,8 @@ ch_chirp_init(
 //    :param uv_loop_t* loop: Reference to a libuv loop
 //    :param ch_log_cb_t log_cb: Callback to logging facility, can be NULL
 //
-//    TODO: Document return value
+//    :return: A chirp error. see: :c:type:`ch_error_t`
+//    :rtype: ch_error_t
 //
 
 // .. c:function::
@@ -245,6 +251,9 @@ ch_chirp_run(const ch_config_t* config, ch_chirp_t** chirp);
 //    :param ch_config_t* config: Chirp config
 //    :param ch_chirp_t** chirp: Out: Pointer to chirp object pointer. Ca be
 //                               NULL
+//
+//    :return: A chirp error. see: :c:type:`ch_error_t`
+//    :rtype: ch_error_t
 //
 // .. c:function::
 extern

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -14,7 +14,6 @@ CFLAGS := \
 	$(CFLAGS)
 
 LDFLAGS := \
-	-Wl,--gc-sections \
 	-luv \
 	-lssl \
 	-lm \

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -28,10 +28,12 @@ endif
 
 ifneq ($(UNAME_S),Darwin)
 CFLAGS += -pthread
+LDFLAGS += -Wl,--gc-sections
+LDFLAGS += -lrt
 else
 CFLAGS += -I/usr/local/opt/openssl/include
+LDFLAGS += -Wl,-dead_strip
 LDFLAGS += -L/usr/local/opt/openssl/lib
-LDFLAGS += -lrt
 endif
 
 

--- a/src/chirp.c
+++ b/src/chirp.c
@@ -123,6 +123,9 @@ _ch_chirp_sig_handler(int);
 //
 //    Closes all chirp instances on sig int.
 //
+//    :param int signo: The signal number, that tells which signal should be
+//                      handled.
+//
 
 // .. c:function::
 static
@@ -378,7 +381,7 @@ ch_identity_t
 ch_chirp_get_identity(ch_chirp_t* chirp)
 //    :noindex:
 //
-//    see: :c:func:`_ch_chirp_closing_down_cb`
+//    see: :c:func:`ch_chirp_get_identity`
 //
 // .. code-block:: cpp
 //
@@ -394,7 +397,7 @@ uv_loop_t*
 ch_chirp_get_loop(ch_chirp_t* chirp)
 //    :noindex:
 //
-//    see: :c:func:`_ch_chirp_closing_down_cb`
+//    see: :c:func:`ch_chirp_get_loop`
 //
 // .. code-block:: cpp
 //
@@ -646,7 +649,7 @@ ch_error_t
 _ch_chirp_verify_cfg(const ch_chirp_t* chirp)
 //    :noindex:
 //
-//    see: :c:func:`_ch_chirp_sig_handler`
+//    see: :c:func:`_ch_chirp_verify_cfg`
 //
 // .. code-block:: cpp
 //

--- a/src/chirp.h
+++ b/src/chirp.h
@@ -13,13 +13,22 @@
 
 #include "sglib.h"
 
-SGLIB_DEFINE_RBTREE_PROTOTYPES(
+// Sglib Prototypes
+// ================
+
+// .. code-block:: cpp
+//
+SGLIB_DEFINE_RBTREE_PROTOTYPES( // NOCOV
     ch_chirp_t,
     _left,
     _right,
     _color_field,
     SGLIB_NUMERIC_COMPARATOR
 )
+
+// Declarations
+// ============
+
 
 // .. c:type:: ch_chirp_flags_t
 //
@@ -34,6 +43,10 @@ SGLIB_DEFINE_RBTREE_PROTOTYPES(
 //
 //       Chirp is closed.
 //
+//    .. c:member:: CH_CHIRP_CLOSING
+//
+//       Chirp is being closed.
+//
 // .. code-block:: cpp
 //
 typedef enum {
@@ -46,14 +59,53 @@ typedef enum {
 //
 //    Chirp object.
 //
+//    .. c:member:: ch_config_t config
+//
+//       The current chirp configuration.
+//
+//    .. c:member:: int closing_tasks
+//
+//       Counter for the number of tasks when closing a connection (e.g.
+//       shutdown). This acts as semaphore.
+//
+//    .. c:member:: uint8_t flags
+//
+//       Holds the flags from :c:type:`ch_chirp_flags_t`, hence indicates
+//       whether chirp is closing, already closed and if the loop shall be
+//       stopped when closing.
+//
 //    .. c:member:: uv_async_t close
 //
-//       async handler to close chirp on the main-loop
+//       Asynchronous handler to close chirp on the main-loop.
 //
-//    .. c:member:: int auto_start
+//    .. c:member:: uv_prepare_t close_check
 //
-//       true if we have to close the libuv loop, otherwise the loop was
-//       supplied by the user
+//       Handle which will run the given callback (close callback, closes chirp
+//       when the closing semaphore reaches zero) once per loop iteration.
+//
+//    .. c:member:: ch_protocol_t protocol
+//
+//       Reference to protocol object. Provides access to connection and data
+//       specific functions.
+//
+//    .. c:member:: ch_encryption_t encryption
+//
+//       Reference to encryption object. Is used when a encrypted connection is
+//       used.
+//
+//    .. c:member:: uv_loop_t* loop
+//
+//       Pointer to the libuv (main) event loop. The event loop is the central
+//       part of libuv’s functionality. It takes care of polling for i/o and
+//       scheduling callbacks to be run based on different sources of events.
+//
+//    .. c:member:: uint8_t identity[16]
+//
+//       Array holding the identity of this chirp configuration.
+//
+//    .. c:member:: uint16_t public_port
+//
+//       The public port which this chirp configuration uses for connections.
 //
 // .. code-block:: cpp
 //
@@ -74,9 +126,9 @@ struct ch_chirp_int_s {
 void
 ch_chirp_close_cb(uv_handle_t* handle);
 //
-//    Reduce callback semaphore.
+//    Reduce closing callback semaphore.
 //
-//    TODO params
+//    :param uv_handle_t* handle: A libuv handle containing the chirp object
 //
 // .. code-block:: cpp
 //

--- a/src/chirp.h
+++ b/src/chirp.h
@@ -3,7 +3,7 @@
 // ============
 //
 // .. code-block:: cpp
-
+//
 #ifndef ch_chirp_h
 #define ch_chirp_h
 
@@ -28,7 +28,6 @@ SGLIB_DEFINE_RBTREE_PROTOTYPES( // NOCOV
 
 // Declarations
 // ============
-
 
 // .. c:type:: ch_chirp_flags_t
 //

--- a/src/chirp_etest.c
+++ b/src/chirp_etest.c
@@ -3,7 +3,7 @@
 // ===================
 //
 // .. code-block:: cpp
-
+//
 #include "libchirp.h"
 
 
@@ -18,7 +18,7 @@ main(
 //    Run chirp
 //
 // .. code-block:: cpp
-
+//
 {
     (void)(argc); // I hate incomplete main headers;
     (void)(argv); // I hate incomplete main headers;

--- a/src/connection.c
+++ b/src/connection.c
@@ -42,7 +42,7 @@ ch_inline
 void
 _ch_cn_partial_write(ch_connection_t* conn);
 //
-//    Called by libuv when pending data has been sent
+//    Called by libuv when pending data has been sent.
 //
 //    :param ch_connection_t* conn: Connection
 //
@@ -162,7 +162,7 @@ void
 _ch_cn_partial_write(ch_connection_t* conn)
 //    :noindex:
 //
-//    see: :c:func:`_ch_cn_partial_write`
+//    See: :c:func:`_ch_cn_partial_write`
 //
 // .. code-block:: cpp
 //

--- a/src/connection.h
+++ b/src/connection.h
@@ -24,21 +24,33 @@
 //
 //    Represents connection flags.
 //
-//    .. c:member:: CH_CN_BUF_USED
-//
-//       The connections buffer is currently used by libuv
-//
 //    .. c:member:: CH_CN_SHUTTING_DOWN
 //
-//       The connection is shutting down
+//       Indicates that the connection is shutting down.
 //
 //    .. c:member:: CH_CN_WRITE_PENDING
 //
-//       There is a write pending.
+//       Indicates that There is a write pending.
 //
 //    .. c:member:: CH_CN_TLS_HANDSHAKE
 //
-//       Handshake is running.
+//      Indicates that a handshake is running.
+//
+//    .. c:member:: CH_CN_ENCRYPTED
+//
+//       Indicates whether the connection is encrypted or not.
+//
+//    .. c:member:: CH_CN_BUF_WTLS_USED
+//
+//       Indicates if TLS for writing is used.
+//
+//    .. c:member:: CH_CN_BUF_RTLS_USED
+//
+//       Indicates if TLS for reading is used.
+//
+//    .. c:member:: CH_CN_BUF_UV_USED
+//
+//       Indicates that the connection buffer is currently used by libuv.
 //
 // .. code-block:: cpp
 //
@@ -55,12 +67,88 @@ typedef enum {
 
 // .. c:type:: ch_connection_t
 //
-//    Connection dictionary implemented as rbtree.
+//    Connection dictionary implemented as red-black tree.
+//
+//    .. c:member:: uint8_t ip_protocol
+//
+//       What IP protocol (IPv4 or IPv6) shall be used for connections.
 //
 //    .. c:member:: uint8_t[16] address
 //
 //       IPv4/6 address of the sender if the message was received.  IPv4/6
 //       address of the recipient if the message is going to be sent.
+//
+//    .. c:member:: int32_t port
+//
+//       The port that shall be used for connections.
+//
+//    .. c:member:: uint8_t[16] remote_identity
+//
+//       The identity of the remote target. This is used for getting the remote
+//       address.
+//
+//    .. c:member:: float max_timeout
+//
+//       The maximum amount of time in seconds that making a connection is
+//       being tried.
+//
+//    .. c:member:: uv_tcp_t client
+//
+//       The TCP handle (TCP stream) of the client, which is used to get the
+//       address of the peer connected to the handle.
+//
+//    .. c:member:: uv_buf* buffer_uv
+//
+//       Pointer to the libuv (data-) buffer data type.
+//
+//    .. c:member:: uv_buf* buffer_wtls
+//
+//       Pointer to the libuv buffer data type for writing data over TLS.
+//
+//    .. c:member:: uv_buf* buffer_rtls
+//
+//       Pointer to the libuv buffer data type for reading data over TLS.
+//
+//    .. c:member:: uv_buf_t buffer_uv_uv
+//
+//       The actual libuv (data-) buffer (using the buffer_uv data type).
+//
+//    .. c:member:: uv_buf_t buffer_wtls_uv
+//
+//       The actual libuv buffer for writing data over TLS (using the
+//       buffer_wtls data type).
+//
+//    .. c:member:: uv_buf_t buffer_any_uv
+//
+//       Generic libuv (data-) buffer used for writing over a connection. The
+//       data type of the buffer must be provided when writing.
+//
+//    .. c:member:: size_t buffer_size
+//
+//       The size that shall be used for initializing the libuv (data-)
+//       buffers.
+//
+//    .. c:member:: uv_write_cb write_callback
+//
+//       A callback which will be called after a sucessful write over a
+//       connection.
+//
+//    .. c:member:: size_t write_written
+//
+//       Holds how many bytes have been written over a connection. This is
+//       typically zero at first and gets increased with each partial write.
+//
+//    .. c:member:: size_t write_size
+//
+//       Indicates how many bytes shall in total be written over a connection.
+//
+//    .. c:member:: ch_buf* write_buffer
+//
+//       Pointer to the write buffer. The buffer that will be written to.
+//
+//    .. c:member:: ch_chirp_t* chirp
+//
+//       Pointer to the chirp object. See: :c:type:`ch_chirp_t`.
 //
 // TODO Complete
 //


### PR DESCRIPTION
* Re-add last commit from forked `sosterwalder/c4irp` repository: sosterwalder/c4irp@1b5edb3
* Adapt building to macOS: Change `--gc-sections` to `-dead_strip` and remove `-lrt`