### PR TITLE
macOS: Ignore already installed brew packages, use relative build path

### DIFF
--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -8,8 +8,8 @@ brew install \
     sphinx-doc \
     graphviz \
     openssl \
-    libuv
-cd ../build && \
+    libuv 2>/dev/null
+cd build && \
 ../configure \
     --dev \
     --doc \


### PR DESCRIPTION
* `brew install` throws an error for already installed packages,
  therefore routing STDERR to /dev/null avoids too early termination
* The base directory is the chirp-repository, not the ci-folder,
  therefore `cd ../build` did not work, it has to be `cd build`
  instead