### PR TITLE
Replace "classic" signal handling with uv_signal_t (WIP)

### DIFF
--- a/include/libchirp.h
+++ b/include/libchirp.h
@@ -20,19 +20,17 @@
 extern char* ch_version;
 
 // .. c:function::
-void
+ch_error_t
 ch_libchirp_cleanup(void);
 //
-//    Cleanup the libchirp mutex, used for thread-safety during
-//    ch_chirp_init and ch_chirp_close.
+//    Cleanup the global libchirp structures, including encryption/libssl
 //
 
 // .. c:function::
-void
+ch_error_t
 ch_libchirp_init(void);
 //
-//    Initialize the libchirp mutex, used for thread-safety during
-//    ch_chirp_init and ch_chirp_close.
+//    Initialize the global libchirp structures, including encryption/libssl
 //
 
 // .. c:function::

--- a/src/chirp.h
+++ b/src/chirp.h
@@ -120,6 +120,11 @@ typedef enum {
 //
 //       Asynchronous handler to close chirp on the main-loop.
 //
+//    .. c:member:: uv_signal_t signals[2]
+//
+//       Libuv handles for managing unix signals. We currently register two
+//       handlers, one for SIGINT, one for SIGTERM.
+//
 //    .. c:member:: uv_prepare_t close_check
 //
 //       Handle which will run the given callback (close callback, closes chirp
@@ -158,6 +163,7 @@ struct ch_chirp_int_s {
     uv_async_t      close;
     uv_async_t      start;
     ch_start_cb_t   start_cb;
+    uv_signal_t     signals[2];
     uv_prepare_t    close_check;
     ch_protocol_t   protocol;
     ch_encryption_t encryption;


### PR DESCRIPTION
This removes the raw unix signal handling and replaces it with libuv's
implementation thereof.

As of this commit, there are still a few open questions that need to be
investigated - namely the error responses for uv_signal_start().

This fixes #54 