### PR TITLE
API for ch_chirp_register_recv_cb supporting actors

### DIFF
--- a/include/libchirp/chirp.h
+++ b/include/libchirp/chirp.h
@@ -363,12 +363,19 @@ ch_chirp_set_auto_stop_loop(ch_chirp_t* chirp);
 // .. c:function::
 CH_EXPORT
 void
-ch_chirp_register_recv_cb(ch_chirp_t* chirp, ch_recv_cb_t recv_cb);
+ch_chirp_register_recv_cb(
+        ch_chirp_t* chirp,
+        ch_recv_cb_t recv_cb,
+        char* actor
+);
 //
-//    Register a callback for receiving a message.
+//    Register a callback, that is called after receiving a message. For each
+//    actor a callback function can be registered.
 //
 //    :param ch_chirp_t* chirp: Pointer to a chirp object.
-//    :param ch_message_t* msg: The message which was received.
+//    :param ch_recv_cb_t* recv_cb: The callback, that will be called after
+//                                  receiving.
+//    :param char* actor: The actor, that sent the message.
 //
 // .. code-block:: cpp
 //

--- a/src/chirp.c
+++ b/src/chirp.c
@@ -1083,7 +1083,11 @@ ch_libchirp_init(void)
 // .. c:function::
 CH_EXPORT
 void
-ch_chirp_register_recv_cb(ch_chirp_t* chirp, ch_recv_cb_t recv_cb)
+ch_chirp_register_recv_cb(
+        ch_chirp_t* chirp,
+        ch_recv_cb_t recv_cb,
+        char* actor
+)
 //    :noindex:
 //
 //    see: :c:func:`ch_chirp_register_recv_cb`
@@ -1091,6 +1095,13 @@ ch_chirp_register_recv_cb(ch_chirp_t* chirp, ch_recv_cb_t recv_cb)
 // .. code-block:: cpp
 //
 {
+    A(chirp->_init == CH_CHIRP_MAGIC, "Not a ch_chirp_t*");
     ch_chirp_int_t* ichirp = chirp->_;
     ichirp->recv_cb = recv_cb;
+    L(
+        chirp,
+        "Registered callback function for actor: %s",
+        actor
+    );
+    // TODO register callback for specific actors
 }

--- a/src/message_etest.c
+++ b/src/message_etest.c
@@ -165,7 +165,7 @@ void
 echo_init_handler(ch_chirp_t* chirp)
 {
     A(chirp->_init == CH_CHIRP_MAGIC, "Not a ch_chirp_t*");
-    ch_chirp_register_recv_cb(chirp, ch_recv_echo_message_cb);
+    ch_chirp_register_recv_cb(chirp, ch_recv_echo_message_cb, "send");
 }
 
 static


### PR DESCRIPTION
``ch_chirp_register_recv_cb`` should register callback functions depending on the sending actor.
To support that, the actor must be also a parameter. This pull request just changes the API of the function ``ch_chirp_register_recv_cb``.