### PR TITLE
Tutorial: Improve agent memory management

### DIFF
--- a/doc/tutorial/collector.c
+++ b/doc/tutorial/collector.c
@@ -53,6 +53,7 @@ static int   upstream_port;
 static void
 sent_cb(ch_chirp_t* chirp, ch_message_t* msg, int status)
 {
+    (void) (chirp);
     (void) (status);
     ch_chirp_release_message(msg);
 }

--- a/doc/tutorial/monitor.c
+++ b/doc/tutorial/monitor.c
@@ -215,6 +215,7 @@ service_update(mon_service_t* msg_svc)
 static void
 new_message_cb(ch_chirp_t* chirp, ch_message_t* msg)
 {
+    (void)(chirp);
     /* Note: This makes some very naive assumptions regarding the peer.  Any
      * respectable network code should NEVER EVER do this! But it keeps the
      * tutorial short, as we don't need code to serialize/unserialize. */
@@ -249,10 +250,6 @@ static void
 show_service_status(mon_service_t* svc, int show_header)
 {
     char* format = "%-32s %22s %10s %-15s\n";
-
-    char      interval_buf[30];
-    char      lastcheck_buf[30];
-    struct tm lastcheck;
 
     if (show_header) {
         printf(format, "Service", "Last update", "Interval", "State");
@@ -373,6 +370,7 @@ static uv_timer_t poll_timer;
 static void
 poll_and_print_status_cb(uv_timer_t* timer)
 {
+    (void)(timer);
 
     time_t now = time(NULL);
     for (size_t i = 0; i < _services_size; i++) {
@@ -412,6 +410,9 @@ static uv_signal_t sighandler;
 static void
 sig_handler_cb(uv_signal_t* handle, int signum)
 {
+    (void)(handle);
+    (void)(signum);
+
     /* First, we stop the sanity check timer. It's not needed anymore */
     uv_timer_stop(&poll_timer);
 


### PR DESCRIPTION
The agent doesn't really need any memory management, as it's running
quite linearly. We also ensure that a service poll cannot run past
a pending service check, as the timeout needs to be at least one
second longer than the connection timeout (of 2 seconds).

Therefore, make the following objects static:

* The message object to be sent upstream
* The service object within the message
* The libuv shutdown request object used to disconnect after a check

While we're at it, we can also use the global service object to store
the polling interval, instead of a separate variable; also shutdown the
check connection upon timeout as well.

See #215 for further details on what needs to be done